### PR TITLE
Add relaxed padding setting to the nclient4

### DIFF
--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -299,7 +299,15 @@ func NewReleaseFromACK(ack *DHCPv4, modifiers ...Modifier) (*DHCPv4, error) {
 
 // FromBytes decodes a DHCPv4 packet from a sequence of bytes, and returns an
 // error if the packet is not valid.
+// Octets after End option are checked against the pad option.
 func FromBytes(q []byte) (*DHCPv4, error) {
+	return FromBytesWithRelaxedPadding(q, false)
+}
+
+// FromBytesWithRelaxedPadding decodes a DHCPv4 packet from a sequence of bytes, and returns an
+// error if the packet is not valid.
+// Octets after the End option are checked or not according to pad option.
+func FromBytesWithRelaxedPadding(q []byte, relaxedPadding bool) (*DHCPv4, error) {
 	var p DHCPv4
 	buf := uio.NewBigEndianBuffer(q)
 
@@ -353,7 +361,7 @@ func FromBytes(q []byte) (*DHCPv4, error) {
 	}
 
 	p.Options = make(Options)
-	if err := p.Options.fromBytesCheckEnd(buf.Data(), true); err != nil {
+	if err := p.Options.fromBytesWithRelaxedPadding(buf.Data(), true, relaxedPadding); err != nil {
 		return nil, err
 	}
 	return &p, nil

--- a/dhcpv4/options.go
+++ b/dhcpv4/options.go
@@ -106,7 +106,7 @@ func (o Options) ToBytes() []byte {
 //
 // Returns an error if any invalid option or length is found.
 func (o Options) FromBytes(data []byte) error {
-	return o.fromBytesCheckEnd(data, false)
+	return o.fromBytesWithRelaxedPadding(data, false, false)
 }
 
 const (
@@ -115,9 +115,9 @@ const (
 	optEnd       = 255
 )
 
-// FromBytesCheckEnd parses Options from byte sequences using the
+// fromBytesWithRelaxedPadding parses Options from byte sequences using the
 // parsing function that is passed in as a paremeter
-func (o Options) fromBytesCheckEnd(data []byte, checkEndOption bool) error {
+func (o Options) fromBytesWithRelaxedPadding(data []byte, checkEndOption bool, relaxedPadding bool) error {
 	if len(data) == 0 {
 		return nil
 	}
@@ -159,6 +159,10 @@ func (o Options) fromBytesCheckEnd(data []byte, checkEndOption bool) error {
 	// up.
 	if !end && checkEndOption {
 		return io.ErrUnexpectedEOF
+	}
+
+	if relaxedPadding {
+		return nil
 	}
 
 	// Any bytes left must be padding.

--- a/dhcpv4/options_test.go
+++ b/dhcpv4/options_test.go
@@ -227,9 +227,10 @@ func TestOptionsMarshal(t *testing.T) {
 
 func TestOptionsUnmarshal(t *testing.T) {
 	for i, tt := range []struct {
-		input     []byte
-		want      Options
-		wantError bool
+		input          []byte
+		relaxedPadding bool
+		want           Options
+		wantError      bool
 	}{
 		{
 			// Buffer missing data.
@@ -258,6 +259,12 @@ func TestOptionsUnmarshal(t *testing.T) {
 			// Option present after the End is a nono.
 			input:     []byte{byte(OptionEnd), 3},
 			wantError: true,
+		},
+		{
+			// Option present after the End if relaxedPadding.
+			input:          []byte{byte(OptionEnd), 3},
+			relaxedPadding: true,
+			want:           Options{},
 		},
 		{
 			input: []byte{byte(OptionEnd)},
@@ -306,7 +313,7 @@ func TestOptionsUnmarshal(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("Test %02d", i), func(t *testing.T) {
 			opt := make(Options)
-			err := opt.fromBytesCheckEnd(tt.input, true)
+			err := opt.fromBytesWithRelaxedPadding(tt.input, true, tt.relaxedPadding)
 			if tt.wantError {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
RFC 2132 says:
`The end option marks the end of valid information in the vendor field.  Subsequent octets should be filled with pad options.`

But it seems that this does not mean that the client should consider packages with non-pad options after the End option invalid, because RFC 2119 explains:
`3. SHOULD   This word, or the adjective "RECOMMENDED", mean that there may exist valid reasons in particular circumstances to ignore a particular item, but the full implications must be understood and carefully weighed before choosing a different course.`
